### PR TITLE
친구 접기, 펼치기 / 사용자와 친구 프로필 모달의 상태 다르게 보이도록 변경

### DIFF
--- a/src/components/Friends.js
+++ b/src/components/Friends.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import styled from "styled-components";
 import noneProfile from "../../public/images/none-profile.png";
 // import bok from "../../public/images/bok.png";
@@ -78,6 +78,9 @@ const FriendsAccordion = styled.div`
 
 const Friends = () => {
   const { userInfo, userDispatch, tempFunc } = useContext(UserContext);
+  const [foldStatus, setFoldStatus] = useState(false);
+
+  //console.log(userInfo);
 
   const clickProfile = (idx) => {
     const modalWrap = document.querySelector("#modalWrap");
@@ -98,42 +101,62 @@ const Friends = () => {
     console.log("open chat");
   };
 
+  const changeFoldStatus = () => {
+    const btn = document.querySelector("#foldBtn");
+    if (foldStatus) {
+      //접혀있으면
+      setFoldStatus(false); //펼치고
+      btn.innerText = "접기";
+    } else {
+      setFoldStatus(true);
+      btn.innerText = "펼치기";
+    } //펼쳐져있으면 접는다.
+  };
+
   return (
     <>
       <FriendsWrap>
         <FriendsInnerWrap>
           <FriendsAccordion>
-            <div>친구</div>
-            <div>접기</div>
+            <div>친구 {userInfo.userInfos.length - 1}</div>
+            <div id="foldBtn" onClick={() => changeFoldStatus()}>
+              접기
+            </div>
           </FriendsAccordion>
-          {userInfo.userInfos.map((user, idx) => {
-            return (
-              <>
-                {idx === 0 ? (
-                  <></>
-                ) : (
-                  <ProfileWrap
-                    key={`profileWrap-${idx}`}
-                    onDoubleClick={() => openChat()}
-                  >
-                    <ProfilePicture
-                      key={`profilePicture-${idx}`}
-                      src={user.src}
-                      onClick={() => clickProfile(idx)}
-                    ></ProfilePicture>
-                    <ProfileContent key={`profileContent-${idx}`}>
-                      <div>{user.name}</div>
-                      {user.content !== undefined ? (
-                        <div>{user.content}</div>
-                      ) : (
-                        <></>
-                      )}
-                    </ProfileContent>
-                  </ProfileWrap>
-                )}
-              </>
-            );
-          })}
+          {foldStatus ? (
+            <></>
+          ) : (
+            <>
+              {userInfo.userInfos.map((user, idx) => {
+                return (
+                  <>
+                    {idx === 0 ? (
+                      <></>
+                    ) : (
+                      <ProfileWrap
+                        key={`profileWrap-${idx}`}
+                        onDoubleClick={() => openChat()}
+                      >
+                        <ProfilePicture
+                          key={`profilePicture-${idx}`}
+                          src={user.src}
+                          onClick={() => clickProfile(idx)}
+                        ></ProfilePicture>
+                        <ProfileContent key={`profileContent-${idx}`}>
+                          <div>{user.name}</div>
+                          {user.content !== undefined ? (
+                            <div>{user.content}</div>
+                          ) : (
+                            <></>
+                          )}
+                        </ProfileContent>
+                      </ProfileWrap>
+                    )}
+                  </>
+                );
+              })}
+            </>
+          )}
         </FriendsInnerWrap>
       </FriendsWrap>
     </>

--- a/src/components/ProfileModal.js
+++ b/src/components/ProfileModal.js
@@ -170,7 +170,7 @@ const ProfileModal = () => {
   };
 
   const showChattingModal = () => {
-    console.log("채팅");
+    // console.log("채팅");
     document.querySelector("#modalWrap").classList.add("hidden");
     document.querySelector("#modalWrap3").classList.remove("hidden");
   };
@@ -228,6 +228,7 @@ const ProfileModal = () => {
                   <Text fontSize="12">
                     {userInfo.userInfos[userInfo.selIdx].name}
                   </Text>
+                  {/* {userInfo.selIdx === 0 ? <></> : <div>수정</div>} */}
                   <Text fontSize="12">
                     {userInfo.userInfos[userInfo.selIdx].content}
                   </Text>
@@ -241,7 +242,7 @@ const ProfileModal = () => {
                     <svg
                       id="chat"
                       width="20"
-                      height="20"
+                      height="25"
                       viewBox="0, 0, 400,400"
                       fill="white"
                     >
@@ -250,8 +251,11 @@ const ProfileModal = () => {
                       </g>
                     </svg>
                   </div>
-                  <Text fontSize="5">나와의 채팅</Text>
+                  <Text fontSize="5">
+                    {userInfo.selIdx === 0 ? <>나와의 채팅</> : <>1:1 채팅</>}
+                  </Text>
                 </BottomInnerThree>
+                {/* {userInfo.selIdx === 0 ? ( */}
                 <BottomInnerThree onClick={editProfile}>
                   <div>
                     <EditSvg
@@ -269,8 +273,14 @@ const ProfileModal = () => {
                       </g>
                     </EditSvg>
                   </div>
-                  <Text fontSize="5">프로필 관리</Text>
+                  <Text fontSize="5">
+                    {userInfo.selIdx === 0 ? <>프로필 관리</> : <>이름 수정</>}
+                  </Text>
                 </BottomInnerThree>
+                {/* ) : (
+                  <></>
+                )} */}
+
                 <BottomInnerThree>
                   <div>
                     <svg


### PR DESCRIPTION
## 📕 제목

사용자와 친구 프로필 모달의 상태 다르게 보이도록 변경
관련이슈 ...

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 접기와 펼치기 상태를 useState로 관리하며 친구를 접고 펼칠 수 있다.
- [x] 사용자는 나와의 채팅, 친구는 1:1 채팅이 나오도록 수정.
- [x] 사용자는 프로필 관리, 친구는 이름 수정이 나오도록 수정.

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
